### PR TITLE
Added routing for entities

### DIFF
--- a/DependencyInjection/CompilerPass/DefaultsProviderCompilerPass.php
+++ b/DependencyInjection/CompilerPass/DefaultsProviderCompilerPass.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\DependencyInjection\CompilerPass;
+
+use Sulu\Component\HttpKernel\SuluKernel;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * This class collects all services with the "sulu_route.defaults_provider" tag.
+ */
+class DefaultsProviderCompilerPass implements CompilerPassInterface
+{
+    const SERVICE_ID = 'sulu_route.routing.defaults_provider';
+    const TAG_NAME = 'sulu_route.defaults_provider';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (SuluKernel::CONTEXT_WEBSITE !== $container->getParameter('sulu.context')) {
+            return;
+        }
+
+        $references = [];
+        foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $tags) {
+            foreach ($tags as $attributes) {
+                $priority = array_key_exists('priority', $attributes) ? $attributes['priority'] : 0;
+                $references[$priority][] = new Reference($id);
+            }
+        }
+
+        if (0 === count($references)) {
+            return;
+        }
+
+        krsort($references);
+        $references = call_user_func_array('array_merge', $references);
+
+        $container->getDefinition(self::SERVICE_ID)->replaceArgument(0, $references);
+    }
+}

--- a/DependencyInjection/SuluRouteExtension.php
+++ b/DependencyInjection/SuluRouteExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * Container extension for sulu-route-bundle.
+ */
+class SuluRouteExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('routing.xml');
+        $loader->load('entity.xml');
+    }
+}

--- a/Entity/Route.php
+++ b/Entity/Route.php
@@ -29,12 +29,17 @@ class Route
     /**
      * @var string
      */
-    private $webspaceKey;
+    private $locale;
 
     /**
      * @var string
      */
     private $entityClass;
+
+    /**
+     * @var string
+     */
+    private $entityId;
 
     /**
      * Get id.
@@ -71,27 +76,27 @@ class Route
     }
 
     /**
-     * Set webspaceKey.
+     * Set locale.
      *
-     * @param string $webspaceKey
+     * @param string $locale
      *
      * @return Route
      */
-    public function setWebspaceKey($webspaceKey)
+    public function setLocale($locale)
     {
-        $this->webspaceKey = $webspaceKey;
+        $this->locale = $locale;
 
         return $this;
     }
 
     /**
-     * Get webspaceKey.
+     * Get locale.
      *
      * @return string
      */
-    public function getWebspaceKey()
+    public function getLocale()
     {
-        return $this->webspaceKey;
+        return $this->locale;
     }
 
     /**
@@ -114,6 +119,30 @@ class Route
     public function setEntityClass($entityClass)
     {
         $this->entityClass = $entityClass;
+
+        return $this;
+    }
+
+    /**
+     * Get entityId.
+     *
+     * @return string
+     */
+    public function getEntityId()
+    {
+        return $this->entityId;
+    }
+
+    /**
+     * Set entityId.
+     *
+     * @param string $entityId
+     *
+     * @return Route
+     */
+    public function setEntityId($entityId)
+    {
+        $this->entityId = $entityId;
 
         return $this;
     }

--- a/Entity/RouteRepository.php
+++ b/Entity/RouteRepository.php
@@ -16,6 +16,13 @@ use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
 /**
  * Contains special queries to find routes.
  */
-class RouteRepository extends EntityRepository
+class RouteRepository extends EntityRepository implements RouteRepositoryInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function findByRoute($route, $locale)
+    {
+        return $this->findOneBy(['route' => $route, 'locale' => $locale]);
+    }
 }

--- a/Entity/RouteRepositoryInterface.php
+++ b/Entity/RouteRepositoryInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\Entity;
+
+/**
+ * Contains special queries to find routes.
+ */
+interface RouteRepositoryInterface
+{
+    /**
+     * Returns new route entity.
+     *
+     * @return Route
+     */
+    public function createNew();
+
+    /**
+     * Returns route-entity by route.
+     *
+     * @param string $route
+     * @param string $localization
+     *
+     * @return Route
+     */
+    public function findByRoute($route, $localization);
+}

--- a/Manager/RouteManagerInterface.php
+++ b/Manager/RouteManagerInterface.php
@@ -12,9 +12,8 @@
 namespace Sulu\Bundle\RouteBundle\Manager;
 
 /**
- * Defines the interface to interact with routes
+ * Defines the interface to interact with routes.
  */
 interface RouteManagerInterface
 {
-
 }

--- a/Resources/config/doctrine/Route.orm.xml
+++ b/Resources/config/doctrine/Route.orm.xml
@@ -3,24 +3,25 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity repository-class="Sulu\Bundle\RouteBundle\Repository\RouteRepository"
+    <entity repository-class="Sulu\Bundle\RouteBundle\Entity\RouteRepository"
             name="Sulu\Bundle\RouteBundle\Entity\Route" table="ro_routes">
 
         <indexes>
             <index columns="route"/>
-            <index columns="webspaceKey"/>
+            <index columns="locale"/>
         </indexes>
 
         <unique-constraints>
-            <unique-constraint columns="route,webspaceKey"/>
+            <unique-constraint columns="route,locale"/>
         </unique-constraints>
 
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
         <field name="route" type="string" length="255"/>
-        <field name="webspaceKey" type="string" length="255"/>
+        <field name="locale" type="string" length="8"/>
         <field name="entityClass" type="string" length="255"/>
+        <field name="entityId" type="string" length="255"/>
 
     </entity>
 </doctrine-mapping>

--- a/Resources/config/entity.xml
+++ b/Resources/config/entity.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="sulu_route.entity.route_repository" class="Sulu\Bundle\RouteBundle\Entity\RouteRepository">
+            <factory service="doctrine.orm.entity_manager" method="getRepository"/>
+            <argument type="string">SuluRouteBundle:Route</argument>
+
+            <tag name="sulu.context" context="website"/>
+        </service>
+    </services>
+</container>

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sulu_route.routing.uri_filter_regexp">null</parameter>
+    </parameters>
+
+    <services>
+        <!-- route-defaults -->
+        <service id="sulu_route.routing.defaults_provider"
+                 class="Sulu\Bundle\RouteBundle\Routing\Defaults\RouteDefaultsProvider">
+            <argument type="collection">%sulu_route.routing.defaults_provider%</argument>
+
+            <tag name="sulu.context" context="website"/>
+        </service>
+
+        <!-- router -->
+        <service id="sulu_route.routing.provider" class="Sulu\Bundle\RouteBundle\Routing\RouteProvider">
+            <argument type="service" id="sulu_route.entity.route_repository"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument type="service" id="sulu_route.routing.defaults_provider"/>
+
+            <tag name="sulu.context" context="website"/>
+        </service>
+
+        <service id="sulu_route.routing.generator" class="Symfony\Cmf\Component\Routing\ProviderBasedGenerator">
+            <argument type="service" id="sulu_route.routing.provider"/>
+
+            <tag name="sulu.context" context="website"/>
+        </service>
+
+        <service id="sulu_route.routing.final_matcher" class="Symfony\Cmf\Component\Routing\NestedMatcher\UrlMatcher">
+            <argument type="service" id="cmf_routing.matcher.dummy_collection"/>
+            <argument type="service" id="cmf_routing.matcher.dummy_context"/>
+
+            <tag name="sulu.context" context="website"/>
+        </service>
+
+        <service id="sulu_route.routing.nested_matcher"
+                 class="Symfony\Cmf\Component\Routing\NestedMatcher\NestedMatcher">
+            <argument type="service" id="sulu_route.routing.provider"/>
+            <argument type="service" id="sulu_route.routing.final_matcher"/>
+
+            <tag name="sulu.context" context="website"/>
+        </service>
+
+        <service id="sulu_route.routing.router" class="Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter">
+            <argument type="service" id="router.request_context"/>
+            <argument type="service" id="sulu_route.routing.nested_matcher"/>
+            <argument type="service" id="sulu_route.routing.generator"/>
+            <argument>%sulu_route.routing.uri_filter_regexp%</argument>
+            <argument type="service" id="event_dispatcher" on-invalid="ignore"/>
+            <argument type="service" id="sulu_route.routing.provider"/>
+
+            <tag name="sulu.context" context="website"/>
+            <tag name="router" priority="20"/>
+        </service>
+    </services>
+</container>

--- a/Routing/Defaults/RouteDefaultsProvider.php
+++ b/Routing/Defaults/RouteDefaultsProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\Routing\Defaults;
+
+/**
+ * Combines multiple defaults-provider.
+ */
+class RouteDefaultsProvider implements RouteDefaultsProviderInterface
+{
+    /**
+     * @var RouteDefaultsProviderInterface[]
+     */
+    private $defaultsProvider;
+
+    /**
+     * @var RouteDefaultsProviderInterface[]
+     */
+    private $defaultsProviderMap = [];
+
+    /**
+     * @param RouteDefaultsProviderInterface[] $defaultsProvider
+     */
+    public function __construct(array $defaultsProvider)
+    {
+        $this->defaultsProvider = $defaultsProvider;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getByEntity($entityClass, $id)
+    {
+        if (!$this->supports($entityClass)) {
+            return;
+        }
+
+        return $this->getDefaultProvider($entityClass)->getByEntity($entityClass, $id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($entityClass)
+    {
+        return null !== $this->getDefaultProvider($entityClass);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    private function getDefaultProvider($entityClass)
+    {
+        if (array_key_exists($entityClass, $this->defaultsProviderMap)) {
+            return $this->defaultsProviderMap[$entityClass];
+        }
+
+        foreach ($this->defaultsProvider as $defaultsProvider) {
+            if ($defaultsProvider->supports($entityClass)) {
+                return $this->defaultsProviderMap[$entityClass] = $defaultsProvider;
+            }
+        }
+    }
+}

--- a/Routing/Defaults/RouteDefaultsProviderInterface.php
+++ b/Routing/Defaults/RouteDefaultsProviderInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\Routing\Defaults;
+
+/**
+ * Provides route-defaults for given entity-class and id.
+ */
+interface RouteDefaultsProviderInterface
+{
+    /**
+     * Returns route-defaults for given entity-class and id.
+     *
+     * @param string $entityClass
+     * @param string $id
+     *
+     * @return array
+     */
+    public function getByEntity($entityClass, $id);
+
+    /**
+     * Returns true if this provider supports given entity-class.
+     *
+     * @param string $entityClass
+     *
+     * @return bool
+     */
+    public function supports($entityClass);
+}

--- a/Routing/RouteProvider.php
+++ b/Routing/RouteProvider.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\Routing;
+
+use PHPCR\Util\PathHelper;
+use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
+use Sulu\Bundle\RouteBundle\Routing\Defaults\RouteDefaultsProviderInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Cmf\Component\Routing\RouteProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Provides symfony-routes by request or name.
+ */
+class RouteProvider implements RouteProviderInterface
+{
+    /**
+     * @var RouteRepositoryInterface
+     */
+    private $routeRepository;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var RouteDefaultsProviderInterface
+     */
+    private $routeDefaultsProvider;
+
+    /**
+     * @param RouteRepositoryInterface $routeRepository
+     * @param RequestAnalyzerInterface $requestAnalyzer
+     * @param RouteDefaultsProviderInterface $routeDefaultsProvider
+     */
+    public function __construct(
+        RouteRepositoryInterface $routeRepository,
+        RequestAnalyzerInterface $requestAnalyzer,
+        RouteDefaultsProviderInterface $routeDefaultsProvider
+    ) {
+        $this->routeRepository = $routeRepository;
+        $this->requestAnalyzer = $requestAnalyzer;
+        $this->routeDefaultsProvider = $routeDefaultsProvider;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRouteCollectionForRequest(Request $request)
+    {
+        $collection = new RouteCollection();
+        $route = PathHelper::relativizePath(
+            $request->getPathInfo(),
+            $this->requestAnalyzer->getResourceLocatorPrefix()
+        );
+
+        $routeEntity = $this->routeRepository->findByRoute('/'.$route, $request->getLocale());
+        if (!$routeEntity || !$this->routeDefaultsProvider->supports($routeEntity->getEntityClass())) {
+            return $collection;
+        }
+
+        // TODO move route-name to entity
+
+        $collection->add(
+            uniqid('sulu_route_', true),
+            new Route(
+                $request->getPathInfo(),
+                $this->routeDefaultsProvider->getByEntity($routeEntity->getEntityClass(), $routeEntity->getEntityId())
+            )
+        );
+
+        return $collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRouteByName($name)
+    {
+        throw new RouteNotFoundException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRoutesByNames($names)
+    {
+        return [];
+    }
+}

--- a/SuluRouteBundle.php
+++ b/SuluRouteBundle.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Bundle\RouteBundle;
 
+use Sulu\Bundle\RouteBundle\DependencyInjection\CompilerPass\DefaultsProviderCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -18,4 +20,13 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class SuluRouteBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new DefaultsProviderCompilerPass());
+    }
 }

--- a/Tests/Unit/Routing/Defaults/DefaultsProviderTest.php
+++ b/Tests/Unit/Routing/Defaults/DefaultsProviderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\Tests\Unit\Routing\Defaults;
+
+use Sulu\Bundle\RouteBundle\Routing\Defaults\RouteDefaultsProvider;
+use Sulu\Bundle\RouteBundle\Routing\Defaults\RouteDefaultsProviderInterface;
+
+class DefaultsProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RouteDefaultsProviderInterface
+     */
+    private $defaultsProvider;
+
+    private $providers = [];
+
+    public function setUp()
+    {
+        $this->providers = [
+            $this->prophesize(RouteDefaultsProviderInterface::class),
+            $this->prophesize(RouteDefaultsProviderInterface::class),
+            $this->prophesize(RouteDefaultsProviderInterface::class),
+        ];
+
+        $this->defaultsProvider = new RouteDefaultsProvider(
+            array_map(
+                function ($provider) {
+                    return $provider->reveal();
+                },
+                $this->providers
+            )
+        );
+    }
+
+    public function testSupportFalse()
+    {
+        foreach ($this->providers as $provider) {
+            $provider->supports('Test')->shouldBeCalled()->willReturn(false);
+        }
+
+        $this->assertFalse($this->defaultsProvider->supports('Test'));
+    }
+
+    public function testSupport()
+    {
+        $this->providers[0]->supports('Test')->shouldBeCalled()->willReturn(true);
+        $this->providers[1]->supports('Test')->shouldNotBeCalled()->willReturn(false);
+        $this->providers[2]->supports('Test')->shouldNotBeCalled()->willReturn(false);
+
+        $this->assertTrue($this->defaultsProvider->supports('Test'));
+    }
+
+    public function testGetByEntityFalse()
+    {
+        foreach ($this->providers as $provider) {
+            $provider->supports('Test')->shouldBeCalled()->willReturn(false);
+            $provider->getByEntity('test', '1')->shouldNotBeCalled();
+        }
+
+        $this->assertNull($this->defaultsProvider->getByEntity('Test', '1'));
+    }
+
+    public function testGetByEntity()
+    {
+        $this->providers[0]->supports('Test')->shouldBeCalled()->willReturn(true);
+        $this->providers[0]->getByEntity('Test', '1')->shouldBeCalled()->willReturn(['test' => 1]);
+        $this->providers[1]->supports('Test')->shouldNotBeCalled()->willReturn(false);
+        $this->providers[1]->getByEntity('test', '1')->shouldNotBeCalled();
+        $this->providers[2]->supports('Test')->shouldNotBeCalled()->willReturn(false);
+        $this->providers[2]->getByEntity('test', '1')->shouldNotBeCalled();
+
+        $this->assertEquals(['test' => 1], $this->defaultsProvider->getByEntity('Test', '1'));
+    }
+}

--- a/Tests/Unit/Routing/RouteProviderTest.php
+++ b/Tests/Unit/Routing/RouteProviderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SuluBundle\Tests\Unit\Routing;
+
+use Sulu\Bundle\RouteBundle\Entity\Route;
+use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
+use Sulu\Bundle\RouteBundle\Routing\Defaults\RouteDefaultsProviderInterface;
+use Sulu\Bundle\RouteBundle\Routing\RouteProvider;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class RouteProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RouteProvider
+     */
+    private $routeProvider;
+
+    /**
+     * @var RouteRepositoryInterface
+     */
+    private $routeRepository;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var RouteDefaultsProviderInterface
+     */
+    private $defaultsProvider;
+
+    protected function setUp()
+    {
+        $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->defaultsProvider = $this->prophesize(RouteDefaultsProviderInterface::class);
+
+        $this->requestAnalyzer->getResourceLocatorPrefix()->willReturn('/de');
+
+        $this->routeProvider = new RouteProvider(
+            $this->routeRepository->reveal(),
+            $this->requestAnalyzer->reveal(),
+            $this->defaultsProvider->reveal()
+        );
+    }
+
+    public function testGetRouteCollectionForRequestNoRoute()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getPathInfo()->willReturn('/de/test');
+        $request->getLocale()->willReturn('de');
+
+        $this->routeRepository->findByRoute('/test', 'de')->willReturn(null);
+
+        $collection = $this->routeProvider->getRouteCollectionForRequest($request->reveal());
+
+        $this->assertCount(0, $collection);
+    }
+
+    public function testGetRouteCollectionForRequestNoSupport()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getPathInfo()->willReturn('/de/test');
+        $request->getLocale()->willReturn('de');
+
+        $routeEntity = $this->prophesize(Route::class);
+        $routeEntity->getEntityClass()->willReturn('Example');
+
+        $this->routeRepository->findByRoute('/test', 'de')->willReturn($routeEntity->reveal());
+        $this->defaultsProvider->supports('Example')->willReturn(false);
+
+        $collection = $this->routeProvider->getRouteCollectionForRequest($request->reveal());
+
+        $this->assertCount(0, $collection);
+    }
+
+    public function testGetRouteCollectionForRequest()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getPathInfo()->willReturn('/de/test');
+        $request->getLocale()->willReturn('de');
+
+        $routeEntity = $this->prophesize(Route::class);
+        $routeEntity->getEntityClass()->willReturn('Example');
+        $routeEntity->getEntityId()->willReturn('1');
+
+        $this->routeRepository->findByRoute('/test', 'de')->willReturn($routeEntity->reveal());
+        $this->defaultsProvider->supports('Example')->willReturn(true);
+        $this->defaultsProvider->getByEntity('Example', '1')->willReturn(['test' => 1]);
+
+        $collection = $this->routeProvider->getRouteCollectionForRequest($request->reveal());
+
+        $this->assertCount(1, $collection);
+        $routes = array_values(iterator_to_array($collection->getIterator()));
+
+        $this->assertEquals('/de/test', $routes[0]->getPath());
+        $this->assertEquals(['test' => 1], $routes[0]->getDefaults());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | TODO

#### What's in this PR?

This PR add the routing component to create routes for saved entities.

#### Why?

You should be able to browse created routes.

#### To Do

- [ ] Create a documentation PR
